### PR TITLE
Fixed a performance regression in MySQL::mysql_num_rows()

### DIFF
--- a/MySQL.php
+++ b/MySQL.php
@@ -309,6 +309,11 @@
         if (is_array($result)) {
             return count($result);
         }
+
+        if (!$result) {
+            return false;
+        }
+
         return $result->rowCount();
     }
 

--- a/MySQL.php
+++ b/MySQL.php
@@ -309,16 +309,7 @@
         if (is_array($result)) {
             return count($result);
         }
-        
-        // Hard clone (cloning PDOStatements doesn't work)
-        $query = $result->queryString;
-        $cloned = $this->mysql_query($query);
-        if ($cloned) {
-            $data = $cloned->fetchAll();
-            return count($data);
-        } else {
-            return false;
-        }
+        return $result->rowCount();
     }
 
     /**


### PR DESCRIPTION
The function was executing the previous statement again. Instead we can just use PDO::rowCount to get the desired information. This solves a performance regression on long running queries.
